### PR TITLE
Fix: Align snake initial position with grid to enable food consumption

### DIFF
--- a/snake.py
+++ b/snake.py
@@ -64,11 +64,17 @@ class SnakeGame:
         self.direction = "Right"
         self.new_direction = "Right"
 
-        # Initial snake (3 segments in the middle)
+        # Calculate middle segment position ensuring grid alignment
+        mid_x_segment = WIDTH // (2 * SEGMENT_SIZE)
+        mid_y_segment = HEIGHT // (2 * SEGMENT_SIZE)
+
+        start_x_head = mid_x_segment * SEGMENT_SIZE
+        start_y_head = mid_y_segment * SEGMENT_SIZE
+
         self.snake_segments = [
-            (WIDTH // 2 - 2 * SEGMENT_SIZE, HEIGHT // 2),
-            (WIDTH // 2 - SEGMENT_SIZE, HEIGHT // 2),
-            (WIDTH // 2, HEIGHT // 2)
+            (start_x_head - 2 * SEGMENT_SIZE, start_y_head),
+            (start_x_head - SEGMENT_SIZE, start_y_head),
+            (start_x_head, start_y_head)
         ]
         self.create_food()
         self.game_loop()


### PR DESCRIPTION
The snake was unable to eat food because its initial starting position and subsequent movements were not aligned with the `SEGMENT_SIZE` grid that the food items were placed on. This meant that the snake's head coordinates would never exactly match the food's coordinates.

This commit modifies the `start_game` method to calculate the snake's initial segment positions by first determining the central segment number (e.g., `WIDTH // (2 * SEGMENT_SIZE)`) and then multiplying by `SEGMENT_SIZE`. This ensures all snake segments, and thus the snake's head, are always on the same grid as the food, allowing the collision detection `new_head == self.food_coords` to function correctly.